### PR TITLE
Fix ctx cancel error in image scan

### DIFF
--- a/scanner/scannerfakes/fake_image_scanner.go
+++ b/scanner/scannerfakes/fake_image_scanner.go
@@ -2,7 +2,6 @@
 package scannerfakes
 
 import (
-	"context"
 	"sync"
 
 	"github.com/rode/collector-image-scanner/scanner"
@@ -28,7 +27,7 @@ type FakeImageScanner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImageScanner) ImageScan(arg1 string, ctx context.Context) {
+func (fake *FakeImageScanner) ImageScan(arg1 string) {
 	fake.imageScanMutex.Lock()
 	fake.imageScanArgsForCall = append(fake.imageScanArgsForCall, struct {
 		arg1 string

--- a/scanner/trivy/scanner.go
+++ b/scanner/trivy/scanner.go
@@ -57,7 +57,7 @@ func (t *trivyImageScanner) Init() error {
 	return nil
 }
 
-func (t *trivyImageScanner) ImageScan(imageUri string, ctx context.Context) {
+func (t *trivyImageScanner) ImageScan(imageUri string) {
 	log := t.logger.Named("ImageScan").With(zap.String("imageUri", imageUri))
 	log.Info("Starting scan")
 
@@ -68,6 +68,7 @@ func (t *trivyImageScanner) ImageScan(imageUri string, ctx context.Context) {
 	}
 	log.Debug("Scan completed", zap.Duration("scan", results.ScanEnd.Sub(results.ScanStart)))
 
+	ctx := context.Background()
 	noteName, err := t.createScanNote(ctx, imageUri)
 	if err != nil {
 		log.Error("Error creating scan note", zap.Error(err))

--- a/scanner/trivy/scanner_test.go
+++ b/scanner/trivy/scanner_test.go
@@ -15,7 +15,6 @@
 package trivy_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -134,8 +133,7 @@ var _ = Describe("TrivyScanner", func() {
 			trivyCommand.ScanReturns(scanResults, scanError)
 
 			Expect(scanner.Init()).NotTo(HaveOccurred())
-			ctx := context.Background()
-			scanner.ImageScan(imageUri, ctx)
+			scanner.ImageScan(imageUri)
 		})
 
 		It("should create a note for the scan", func() {

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -14,12 +14,10 @@
 
 package scanner
 
-import "context"
-
 //go:generate counterfeiter -generate
 
 //counterfeiter:generate . ImageScanner
 type ImageScanner interface {
-	ImageScan(string, context.Context)
+	ImageScan(string)
 	Init() error
 }

--- a/server/server.go
+++ b/server/server.go
@@ -40,12 +40,12 @@ func NewCollectorImageScannerServer(logger *zap.Logger, scanner scanner.ImageSca
 	}
 }
 
-func (s *collectorImageScannerServer) StartImageScan(ctx context.Context, request *v1alpha1.CreateImageScanRequest) (*emptypb.Empty, error) {
+func (s *collectorImageScannerServer) StartImageScan(_ context.Context, request *v1alpha1.CreateImageScanRequest) (*emptypb.Empty, error) {
 	if !imageUriPattern.MatchString(request.ImageUri) {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid Image URI")
 	}
 
-	go s.scanner.ImageScan(request.ImageUri, ctx)
+	go s.scanner.ImageScan(request.ImageUri)
 
 	return &emptypb.Empty{}, nil
 }


### PR DESCRIPTION
The request context is in the canceled state at the end of the request, so we can't pass it to Rode in the goroutine:
```
2021-09-16T15:13:38.149-0400	INFO	TrivyImageScanner.ImageScan	trivy/scanner.go:62	Starting scan	{"imageUri": "curlimages/curl@sha256:6e0a786e3e5181df00eaf3a0a1749c18a6bb20b01c9bd192ea72176ce8a1c94b"}
2021-09-16T15:13:38.191-0400	DEBUG	TrivyImageScanner.ImageScan	trivy/scanner.go:69	Scan completed	{"imageUri": "curlimages/curl@sha256:6e0a786e3e5181df00eaf3a0a1749c18a6bb20b01c9bd192ea72176ce8a1c94b", "scan": "40.523443ms"}
2021-09-16T15:13:38.191-0400	ERROR	TrivyImageScanner.ImageScan	trivy/scanner.go:73	Error creating scan note	{"imageUri": "curlimages/curl@sha256:6e0a786e3e5181df00eaf3a0a1749c18a6bb20b01c9bd192ea72176ce8a1c94b", "error": "rpc error: code = Canceled desc = context canceled"}
github.com/rode/collector-image-scanner/scanner/trivy.(*trivyImageScanner).ImageScan
```