### PR TITLE
Sending scan failures to Rode

### DIFF
--- a/scanner/trivy/scanner_test.go
+++ b/scanner/trivy/scanner_test.go
@@ -107,7 +107,7 @@ var _ = Describe("TrivyScanner", func() {
 
 			imageUri = fake.Word()
 			scanResults = &trivy.ScanOutput{
-				Report: &report.Report{},
+				Report:     &report.Report{},
 				ScanStatus: trivy.ScanningCompleted,
 			}
 			scanError = nil

--- a/scanner/trivy/scanner_test.go
+++ b/scanner/trivy/scanner_test.go
@@ -220,8 +220,14 @@ var _ = Describe("TrivyScanner", func() {
 
 				_, actualRequest, _ := rode.BatchCreateOccurrencesArgsForCall(0)
 
-				for _, occurrence := range actualRequest.Occurrences {
-					Expect(occurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
+				for i, actualOccurrence := range actualRequest.Occurrences {
+					expectedStatus := discovery_go_proto.Discovered_SCANNING
+					if i == 1 {
+						expectedStatus = discovery_go_proto.Discovered_FINISHED_FAILED
+					}
+
+					Expect(actualOccurrence.Kind).To(Equal(common_go_proto.NoteKind_DISCOVERY))
+					Expect(actualOccurrence.GetDiscovered().Discovered.AnalysisStatus).To(Equal(expectedStatus))
 				}
 			})
 		})


### PR DESCRIPTION
instead of just printing errors in the collector logs